### PR TITLE
Use GitHub branch name in AWS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ First run ```npm install```
 - Test Locally: 
   - ```npm start``` (or for a Python program: ```npm run startpy```)
 - Deploy: 
-  - ```npm run deploy prod```
-  - ```npm run deploy dev```
+  - ```npm run deploy```
 - Destroy: (removes all objects from AWS)
-  - ```npm run destroy prod```
-  - ```npm run destroy dev``` 
+  - ```npm run destroy```
 - Clean: 
   - ```npm run clean``` (removes local temp files)
 

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -34,25 +34,38 @@ try {
   let deploy_type = gitBranch; // prod or dev
 
   // determine Lambda name
-  if (deploy_type === 'production') {
+  if (deploy_type === 'production' || deploy_type === 'main') {
     config.prog_name = config.lambda_name;
     config.build_dir = 'build/prod';
   } else if (deploy_type === 'development') {
-    config.prog_name = config.lambda_name + '-dev';
+    config.prog_name = config.lambda_name + '_dev';
     config.build_dir = 'build/dev';
   } else {
-    config.prog_name = config.lambda_name + '-' + deploy_type;
+    config.prog_name = config.lambda_name + '_' + deploy_type;
     config.build_dir = 'build/' + deploy_type;
   }
 
-  // Set domain name for API Gateway
+  // Set domain name and certificate for API Gateway
   if (config.lambda_options.api_gateway === 'true') {
-    if (deploy_type === 'production') {
-      config.domain_name = config.api_gateway_settings.domain_name;
+    if (deploy_type === 'production' || deploy_type === 'main') {
+      config.domain_name = config.api_gateway_settings.production_domain_name;
+      config.certificate_arn = config.api_gateway_settings.production_certificate_arn;
     } else if (deploy_type === 'development') {
-      config.domain_name = 'dev-' + config.api_gateway_settings.domain_name;
+      if (config.api_gateway_settings.development_domain_name === null) {
+        config.domain_name = 'dev-' + config.api_gateway_settings.production_domain_name;
+        config.certificate_arn = config.api_gateway_settings.production_certificate_arn;
+      } else {
+        config.domain_name = 'dev-' + config.api_gateway_settings.development_domain_name;
+        config.certificate_arn = config.api_gateway_settings.development_certificate_arn;
+      }
     } else {
-      config.domain_name = deploy_type + '-' + config.api_gateway_settings.domain_name;
+      if (config.api_gateway_settings.development_domain_name === null) {
+        config.domain_name = deploy_type + '-' + config.api_gateway_settings.production_domain_name;
+        config.certificate_arn = config.api_gateway_settings.production_certificate_arn;
+      } else {
+        config.domain_name = deploy_type + '-' + config.api_gateway_settings.development_domain_name;
+        config.certificate_arn = config.api_gateway_settings.development_certificate_arn;
+      }
     }
   } else {
     config.domain_name = '';

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -16,6 +16,7 @@ try {
   const file = await fs.readFile(`${__deploy_dir}/deploy.yaml`, 'utf8');
   let config = YAML.parse(file);
   config.deploy_dir = __deploy_dir;
+  const gitBranch = execSync('git branch --show-current').toString().trim();
 
   // get Lambda environment variables from .env file
   try {
@@ -26,19 +27,22 @@ try {
   }
 
   // Get dev or prod from command line
-  if (process.argv.length !== 3 || (process.argv[2] !== 'prod' && process.argv[2] !== 'dev')) {
-    console.error('Usage: npm run deploy prod|dev');
-    process.exit(1);
-  }
-  let deploy_type = process.argv[2]; // prod or dev
+  // if (process.argv.length !== 3 || (process.argv[2] !== 'prod' && process.argv[2] !== 'dev')) {
+  //   console.error('Usage: npm run deploy prod|dev');
+  //   process.exit(1);
+  // }
+  let deploy_type = gitBranch; // prod or dev
 
   // determine Lambda name
-  if (deploy_type === 'prod') {
-    config.prog_name = config.lambda_names.production_name;
+  if (deploy_type === 'production') {
+    config.prog_name = config.lambda_names.lambda_name;
     config.build_dir = 'build/prod';
-  } else if (deploy_type === 'dev') {
-    config.prog_name = config.lambda_names.development_name;
+  } else if (deploy_type === 'development') {
+    config.prog_name = config.lambda_names.lambda_name + '-dev';
     config.build_dir = 'build/dev';
+  } else {
+    config.prog_name = config.lambda_names.lambda_name + '-' + deploy_type;
+    config.build_dir = 'build/' + deploy_type;
   }
 
   // Set domain name for API Gateway

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -35,22 +35,24 @@ try {
 
   // determine Lambda name
   if (deploy_type === 'production') {
-    config.prog_name = config.lambda_names.lambda_name;
+    config.prog_name = config.lambda_name;
     config.build_dir = 'build/prod';
   } else if (deploy_type === 'development') {
-    config.prog_name = config.lambda_names.lambda_name + '-dev';
+    config.prog_name = config.lambda_name + '-dev';
     config.build_dir = 'build/dev';
   } else {
-    config.prog_name = config.lambda_names.lambda_name + '-' + deploy_type;
+    config.prog_name = config.lambda_name + '-' + deploy_type;
     config.build_dir = 'build/' + deploy_type;
   }
 
   // Set domain name for API Gateway
   if (config.lambda_options.api_gateway === 'true') {
-    if (deploy_type === 'prod') {
-      config.domain_name = config.api_gateway_settings.production_domain_name;
-    } else if (deploy_type === 'dev') {
-      config.domain_name = config.api_gateway_settings.development_domain_name;
+    if (deploy_type === 'production') {
+      config.domain_name = config.api_gateway_settings.domain_name;
+    } else if (deploy_type === 'development') {
+      config.domain_name = 'dev-' + config.api_gateway_settings.domain_name;
+    } else {
+      config.domain_name = deploy_type + '-' + config.api_gateway_settings.domain_name;
     }
   } else {
     config.domain_name = '';

--- a/deploy/destroy.js
+++ b/deploy/destroy.js
@@ -10,7 +10,7 @@ try {
 
   let buildDir = 'build/';
 
-  if (deployType === 'production') {
+  if (deployType === 'production' || deployType === 'main') {
     buildDir += 'prod';
   } else if (deployType === 'development') {
     buildDir += 'dev';

--- a/deploy/destroy.js
+++ b/deploy/destroy.js
@@ -4,22 +4,18 @@ import { execSync } from 'child_process';
 
 try {
   // Running dev or prod?
-  if (process.argv.length === 2) {
-    console.error('Usage: npm run destroy prod|dev');
-    process.exit(1);
-  }
-  let args = process.argv.slice(2);
-  let deployType = args[0];
+  const gitBranch = execSync('git branch --show-current').toString().trim();
+  
+  let deployType = gitBranch;
 
   let buildDir = 'build/';
 
-  if (deployType === 'prod') {
-    buildDir += deployType;
-  } else if (deployType === 'dev') {
-    buildDir += deployType;
+  if (deployType === 'production') {
+    buildDir += 'prod';
+  } else if (deployType === 'development') {
+    buildDir += 'dev';
   } else {
-    console.error('Usage: npm run destroy prod|dev');
-    process.exit(1);
+    buildDir += deployType
   }
 
   execSync(`cd ${buildDir} && terraform init && terraform destroy -auto-approve`, { stdio: 'inherit' });

--- a/deploy/example.deploy.yaml
+++ b/deploy/example.deploy.yaml
@@ -1,8 +1,6 @@
 # Required Fields
 
-lambda_names:
-  production_name: template      # Name of the production lambda
-  development_name: template-dev # Name of the development lambda
+lambda_name: template           # Name of the production lambda
 region: us-east-1                # AWS region
 state_bucket: avl-tfstate-store  # S3 bucket to store terraform state
 nodejs_or_python: nodejs         # set to nodejs or python
@@ -29,8 +27,7 @@ vpc_settings:
 
 # If API Gateway is true, then these API Gateway settings are used
 api_gateway_settings:
-  production_domain_name: template.ashevillenc.gov
-  development_domain_name: dev-template.ashevillenc.gov
+  domain_name: template.ashevillenc.gov
   certificate_arn: arn:aws:acm:us-east-1:xx:certificate/xxx
 
 

--- a/deploy/example.deploy.yaml
+++ b/deploy/example.deploy.yaml
@@ -1,6 +1,6 @@
 # Required Fields
 
-lambda_name: template           # Name of the production lambda
+lambda_name: template           # Name of the production lambda. GitHub branch name will be added as a suffix for dev and feature branches
 region: us-east-1                # AWS region
 state_bucket: avl-tfstate-store  # S3 bucket to store terraform state
 nodejs_or_python: nodejs         # set to nodejs or python
@@ -26,8 +26,11 @@ vpc_settings:
     - sg-xx
 
 # If API Gateway is true, then these API Gateway settings are used
+# If the domain/cert for prod and dev is the same, omit the dev domain/cert
 api_gateway_settings:
-  domain_name: template.ashevillenc.gov
-  certificate_arn: arn:aws:acm:us-east-1:xx:certificate/xxx
+  production_domain_name: example.com
+  development_domain_name: template.ashevillenc.gov # No need to include "dev" in the name. GitHub branch name will be added as a prefix for dev and feature branches
+  production_certificate_arn: arn:aws:acm:us-east-1:xx:certificate/xxx
+  development_certificate_arn: arn:aws:acm:us-east-1:xx:certificate/xyz
 
 

--- a/deploy/settings/api_gateway_settings.js
+++ b/deploy/settings/api_gateway_settings.js
@@ -23,7 +23,7 @@ resource "aws_apigatewayv2_api" "${config.prog_name}" {
 resource "aws_apigatewayv2_domain_name" "domain-name-${config.prog_name}" {
   domain_name = "${config.domain_name}"
   domain_name_configuration {
-    certificate_arn = "${config.api_gateway_settings.certificate_arn}"
+    certificate_arn = "${config.certificate_arn}"
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }


### PR DESCRIPTION
The updates here will no longer require the user to input "dev" or "prod" when running npm run deploy/destroy.  Instead, the name of the active GitHub branch will be used when creating AWS resources.